### PR TITLE
Revert "poplar_kddi: extract: Don't add Sony camera service to camera…

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -80,10 +80,4 @@ fix_product_path product/etc/permissions/lpa.xml
 fix_product_path product/etc/permissions/qcrilhook.xml
 fix_product_path product/etc/permissions/telephonyservice.xml
 
-#
-# Don't add Sony camera service to camera-daemon tasks
-#
-
-sed -i 's/\/dev\/cpuset\/camera-daemon\/tasks //g' "${DEVICE_ROOT}"/vendor/etc/init/vendor.somc.hardware.camera.provider@1.0-service.rc
-
 "${MY_DIR}"/setup-makefiles.sh


### PR DESCRIPTION
…-daemon tasks"

Turns out, this was not the problem with stuck cpu frequencies. We can actually make use of this now.

This reverts commit b8d37dd120e683f9e737d40cf3bbaee86d92dcd3.